### PR TITLE
Support x64 Arch libssl

### DIFF
--- a/cmake/FindLibssl.cmake
+++ b/cmake/FindLibssl.cmake
@@ -34,7 +34,7 @@ find_path(Libssl_INCLUDE_DIR openssl/ssl.h NO_DEFAULT_PATH PATHS
 
 find_library(Libssl_LIBRARY NO_DEFAULT_PATH
   NAMES ssl
-  PATHS ${HT_DEPENDENCY_LIB_DIR} /usr/local/ssl/lib /lib /lib64 /usr/lib /usr/lib64 /usr/local/lib /usrlocal/lib64 /opt/local/lib
+  PATHS ${HT_DEPENDENCY_LIB_DIR} /usr/local/ssl/lib /lib /usr/lib/x86_64-linux-gnu/ /lib64 /usr/lib /usr/lib64 /usr/local/lib /usrlocal/lib64 /opt/local/lib
 )
 
 find_library(Libcrypto_LIBRARY NO_DEFAULT_PATH


### PR DESCRIPTION
add search path for linking libssl while compiling if not found on the usual directories (arch x64)