### PR TITLE
add packaging files for python hypertable client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,5 @@ run/monitoring/*stats.txt
 /src/rb/Monitoring/test.log
 /src/cc/Hypertable/Master/#RangeServerStatistics.h#
 /src/rb/Monitoring/Monitoring
+/src/py/ThriftClient/dist/
+/src/py/ThriftClient/hypertable.egg-info/

--- a/src/py/ThriftClient/MANIFEST.in
+++ b/src/py/ThriftClient/MANIFEST.in
@@ -1,0 +1,1 @@
+prune gen-py

--- a/src/py/ThriftClient/README.rst
+++ b/src/py/ThriftClient/README.rst
@@ -1,0 +1,30 @@
+Hypertable clinet for python
+============================
+
+Check out the `documentation`__ for more complete examples.
+
+.. __: http://hypertable.com/documentation/developer_guide/python/
+
+
+Installation
+------------
+
+Install python hypertable client:
+
+.. code-block:: console
+
+    pip install hypertable
+
+
+Creating a thrift client
+------------------------
+
+All of the examples in this document reference a pointer to a Thrift client object.  The following code snippet illustrates how to create a Thrift client object connected to a ThriftBroker listening on the default port (15867) on localhost.  To change the ThriftBroker location, just change "localhost" to the domain name of the machine on which the ThriftBroker is running.
+
+.. code-block:: python
+
+    try:
+        client = ThriftClient("localhost", 15867)
+    except Exception as e:
+        print e
+        sys.exit(1)

--- a/src/py/ThriftClient/hyperthrift
+++ b/src/py/ThriftClient/hyperthrift
@@ -1,0 +1,1 @@
+gen-py/hyperthrift

--- a/src/py/ThriftClient/setup.py
+++ b/src/py/ThriftClient/setup.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+import os
+from setuptools import setup, find_packages
+
+README_RST = os.path.join(os.path.dirname(__file__), 'README.rst')
+with open(README_RST) as readme:
+    long_description = readme.read()
+
+setup(
+    name='hypertable',
+    version='0.9.8.9',
+    description='Python client for Hypertable',
+    long_description=long_description,
+
+    packages=find_packages(exclude=['gen-py.*', 'gen-py']),
+    scripts=['client_test.py'],
+    install_requires=['thrift'],
+
+    url='http://hypertable.com/documentation/developer_guide/python/',
+    license='GPLv3',
+)


### PR DESCRIPTION
I adopt existing hypertable python client sources for python packaging.

After merge please register hypertable at python package index(https://pypi.python.org/pypi) and upload hypertable python package.

```
cd src/py/ThriftClient
# Create python source distribution and upload it to python package index
python setup.py sdist upload
```

This should be done on every release of `hypertable`(if there are any change in python package).

After that there will be no necessary to install `hypertable` distribution instead install python package.

As simple as:

```
pip install hypertable
```
